### PR TITLE
Adjustments for #43

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Suggests:
     httptest (>= 2.0.0),
     jsonlite,
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat (>= 2.1.0)
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Depends:
 Imports:
     openxlsx,
     digest,
-    methods
+    methods,
+    tinytex
 Suggests:
     covr,
     httptest (>= 2.0.0),

--- a/R/writeLatex.R
+++ b/R/writeLatex.R
@@ -101,12 +101,20 @@ writeLatex <- function(data_summary, theme = themeDefaultLatex(),
 
     if (!is.null(filename)) {
         filename <- paste0(filename, ".tex")
+        filename <- gsub(" ", "-", filename) # Some systems dislike spaces
         cat(out, sep = "\n", file = filename)
         if (pdf) {
             if (logging) {
                 print("PDF-ing")
             }
-            pdflatex(filename, open)
+            if("tinytex" %in% rownames(installed.packages())) {
+                tinytex::pdflatex(filename, bib_engine = NULL)
+                if(open) {
+                    file.open(filename)
+                }
+            } else {
+                pdflatex(filename, open)
+            }
         }
     }
     return(invisible(data_summary))

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -1,0 +1,22 @@
+context("theme")
+
+test_that("Setting latex_round_percentages_exception works",{
+  toplines_theme <- themeNew(
+    default_theme = themeDefaultLatex(),
+    format_title = list(decoration = "bold"),
+    format_subtitle = list(decoration = "bold", font_size = 14),
+    format_var_description = list(include_q_number = TRUE, background_color = "gray"), 
+    format_var_filtertext = list(decoration = "italic", font_size = 8),
+    latex_headtext = "tbc", 
+    latex_foottext = "tbc",
+    latex_round_percentages = TRUE,
+    latex_round_percentages_exception = c('demfirstchoice', 'demsecondchoice'), 
+    latex_max_lines_for_tabular = 15, 
+    latex_table_align = 'g', 
+    format_totals_row = NULL,
+    format_unweighted_n = NULL,
+    format_weighted_n = NULL,
+    one_per_sheet = FALSE)
+  expect_true(toplines_theme$latex_round_percentages)
+  expect_equal(toplines_theme$latex_round_percentages_exception, c('demfirstchoice', 'demsecondchoice'))
+})

--- a/tests/testthat/test-write-latex.R
+++ b/tests/testthat/test-write-latex.R
@@ -24,8 +24,8 @@ with_temp_dir({
 
     test_that("Write Latex crosstab", {
         writeLatex(cs)
-        expect_true(file.exists("Example Dataset with Nets.tex"))
-        tex <- readLines("Example Dataset with Nets.tex")
+        expect_true(file.exists("Example-Dataset-with-Nets.tex"))
+        tex <- readLines("Example-Dataset-with-Nets.tex")
         expect_equal(tex[1], "\\documentclass[landscape]{article}")
         ref <- readLines(tabbook_reference)
         expect_identical(tex, ref)
@@ -36,26 +36,26 @@ with_temp_dir({
         # file.copy("Example Dataset with Nets.tex", "~/c/crunchtabs/tests/testthat/ref/tabbook1.tex", overwrite=TRUE)
 
         writeLatex(cs, sample_desc = "Adults")
-        expect_silent(tex <- readLines("Example Dataset with Nets.tex"))
+        expect_silent(tex <- readLines("Example-Dataset-with-Nets.tex"))
         expect_equal(tex[90], "Sample  &  Adults \\\\ ")
         writeLatex(cs, moe = 0.2, field_period = "2018-01-01 to 2018-01-02")
 
         skip_on_appveyor()
-        writeLatex(cs, pdf = TRUE)
-        expect_true(file.exists("Example Dataset with Nets.pdf"))
-        expect_output(writeLatex(cs, pdf = TRUE, logging = TRUE), "PDF-ing")
-        writeLatex(cs, subtitle = "something", pdf = TRUE)
-        writeLatex(cs, sample_desc = "Adults", pdf = TRUE)
-        writeLatex(cs, moe = 0.2, field_period = "2018-01-01 to 2018-01-02", pdf = TRUE)
+        suppressWarnings(writeLatex(cs, pdf = TRUE))
+        expect_true(file.exists("Example-Dataset-with-Nets.pdf"))
+        expect_output(suppressWarnings(writeLatex(cs, pdf = TRUE, logging = TRUE)), "PDF-ing")
+        suppressWarnings(writeLatex(cs, subtitle = "something", pdf = TRUE))
+        suppressWarnings(writeLatex(cs, sample_desc = "Adults", pdf = TRUE))
+        suppressWarnings(writeLatex(cs, moe = 0.2, field_period = "2018-01-01 to 2018-01-02", pdf = TRUE))
 
         theme <- themeNew(default_theme = themeDefaultLatex(), digits = 1)
-        writeLatex(cs, theme = theme, pdf = TRUE)
+        suppressWarnings(writeLatex(cs, theme = theme, pdf = TRUE))
         theme <- themeNew(default_theme = theme, font_size = 20)
-        writeLatex(cs, theme = theme, pdf = TRUE)
+        suppressWarnings(writeLatex(cs, theme = theme, pdf = TRUE))
         theme <- themeNew(default_theme = theme, format_unweighted_n=list(latex_round_percentages = TRUE))
-        writeLatex(cs, theme = theme, pdf = TRUE)
+        suppressWarnings(writeLatex(cs, theme = theme, pdf = TRUE))
         theme <- themeNew(default_theme = theme, format_weighted_n=list(latex_add_parenthesis = TRUE))
-        writeLatex(cs, theme = theme, pdf = TRUE)
+        suppressWarnings(writeLatex(cs, theme = theme, pdf = TRUE))
     })
 
     test_that("Write Latex toplines", {
@@ -72,13 +72,13 @@ with_temp_dir({
         # file.copy("topline1.tex", "~/c/crunchtabs/tests/testthat/ref/topline1.tex", overwrite=TRUE)
 
         skip_on_appveyor()
-        writeLatex(ts, pdf = TRUE)
-        expect_true(file.exists("Example Dataset with Nets.pdf"))
+        suppressWarnings(writeLatex(ts, pdf = TRUE))
+        expect_true(file.exists("Example-Dataset-with-Nets.pdf"))
 
         # Test that fix for #36: previously failed to generate PDF
         bad <- ts
         ts$results[[1]]$description <- bad_description
-        writeLatex(ts, pdf = TRUE, file="topline2")
+        suppressWarnings(writeLatex(ts, pdf = TRUE, file="topline2"))
         expect_true(file.exists("topline2.pdf"))
     })
 })


### PR DESCRIPTION
Refs #43 

- [ ] Fixes base sizes shown when exception made.
- [x] Enforces using tinytex if installed (more reliable)
- [x] Fixes warnings for new theme opts
- [x] Adds validation bypass for latex_round_percentages_exception
- [x] Set spaces as "-" in output files to avoid cross platform issues (May need to check with people on this one)