### PR TITLE
Flipping grids, exceptionally

### DIFF
--- a/R/recontactQuestion.R
+++ b/R/recontactQuestion.R
@@ -24,8 +24,14 @@ recontact_toplines <- function(dataset, questions, suffixes, labels,
   names(groupings) <- questions
   vars <- unlist(groupings)
 
+  get_weights <- function(dataset) {
+    list(
+      weight_spec <- alias()
+    )
+  }
+
   if (is.null(weights)) {
-    weight_spec <- weight(ds)
+    weight_spec <- weight(dataset)
   } else {
     weight_spec <- lapply(suffixes, function(x) vars[grepl(x, vars)])
     names(weight_spec) <- weights

--- a/R/tex-table.R
+++ b/R/tex-table.R
@@ -5,7 +5,8 @@
 #'
 #' @param df An object from \link{reformatLatexResults}
 #' @param theme A theme object from \link{themeNew}
-latexTableBody <- function(df, theme) {
+#' @param alias The variable's alias
+latexTableBody <- function(df, theme, alias = NULL) {
   # The input "df" object is shaped like this:
   # List of 9
   #  $ top            : NULL
@@ -156,7 +157,7 @@ latexTableBody <- function(df, theme) {
   # Turn each table in `data` into a LaTeX table string
   if (topline_catarray) {
 
-    if(theme$latex_flip_grids) { # replace with theme option
+    if (theme$latex_flip_grids | alias %in% theme$latex_flip_specific_grids) {
       data$body <- as.data.frame(t(data$body), check.names = FALSE, stringsAsFactors = FALSE)
     }
     # Apparently you can't have any extra table members for these, only "body"
@@ -327,7 +328,7 @@ tableHeader.ToplineVar <- function(var, theme) {
 tableHeader.ToplineCategoricalArray <- function(var, theme) {
   header_row <- newline
 
-  if (theme$latex_flip_grids) {
+  if (theme$latex_flip_grids | var$alias %in% theme$latex_flip_specific_grids) {
     col_names <- var$subnames
   } else {
     col_names <- sapply(var$inserts_obj, name)

--- a/R/theme.R
+++ b/R/theme.R
@@ -58,7 +58,8 @@
 #' \item{latex_round_percentages}{In Latex, a logical. In Latex, should percentages be recalculated so they do not exceed 100\% where necessary? Defaults to FALSE.}
 #' \item{latex_round_percentages_exception}{In Latex, an optional character. A list of variable aliases that should have the opposite behaviour of that specified in latex_round_percentages.}
 #' \item{latex_table_align}{In Latex, a character. A character string indicating what the table alignment should be. Defaults to 'r'.}
-#' \item{latex_flip_grids}{In Latex, a logical. Categorical arrays will be flipped so that there rows are now transposed to columns.}
+#' \item{latex_flip_grids}{In Latex, a logical. Categorical arrays will be flipped so that there rows are now transposed to columns.},
+#' \item{latex_flip_specific_grids}{An optional vector of aliases whose presentation should be transposed}
 #' \item{logo}{An optional list. Information about the logo to be included in the tables.}
 #' Includes:
 #' \itemize{
@@ -427,6 +428,7 @@ validators_to_use <- list(
   enforce_onehundred = c(class = "logical", len = 1, missing = FALSE, default = FALSE),
   latex_table_align = c(class = "character", len = 1, missing = FALSE, default = ""),
   latex_flip_grids = c(class = "logical", len = 1, missing = FALSE, default = FALSE),
+  latex_flip_specific_grids = c(class = "character", len = NA, missing = TRUE),
   latex_page_numbers = c(class = "logical", len = 1, missing = FALSE, default = TRUE),
   logo = list(missing = TRUE, include = list("file", "startRow", "startCol",
                                              "width", "height", "units", "dpi")),
@@ -473,7 +475,8 @@ theme_validator <- function(theme) {
     "latex_foottext", "latex_headtext", "latex_max_lines_for_tabular",
     "latex_multirowheaderlines", "latex_round_percentages", "enforce_onehundred",
     "latex_flip_grids","latex_round_percentages_exception","latex_page_numbers",
-    "latex_table_align", "logo", "one_per_sheet","valign", "pagebreak_in_banner")
+    "latex_table_align", "logo", "one_per_sheet","valign", "pagebreak_in_banner",
+    "latex_flip_specific_grids")
 
   ignore <- setdiff(names(theme), theme_required)
   if (length(ignore) > 0) {

--- a/R/writeLatex.R
+++ b/R/writeLatex.R
@@ -157,7 +157,7 @@ latexReportTables <- function(results, banner, theme) {
 
       # PT: because this is a loop, header is singular (i.e. it's only one table at a time).
       header <- tableHeader(x, theme)
-      body <- sapply(content, latexTableBody, theme = theme)
+      body <- sapply(content, latexTableBody, theme = theme, alias = x$alias)
 
       footer <- ifelse(
         x$longtable | !theme$topline,
@@ -190,7 +190,7 @@ latexReportTables <- function(results, banner, theme) {
       x$longtable <- calculateIfLongtable(x, theme)
 
       header <- tableHeader(x, theme)
-      body <- latexTableBody(x, theme)
+      body <- latexTableBody(x, theme, x$alias)
       footer <- ifelse(
         x$longtable | !theme$topline,
         "\n\\end{longtable}",

--- a/dev-misc/recontact_toplines.R
+++ b/dev-misc/recontact_toplines.R
@@ -36,7 +36,7 @@ weight(ds) <- ds$weight1
 ds$q1_pre <- copyVariable(ds$q1, deep = TRUE, name = "Pet name pre")
 ds$q1_post <- copyVariable(ds$q1, deep = TRUE, name = "Pet name post")
 ds$country_pre <- copyVariable(ds$country, deep = TRUE, name = "Country pre")
-ds$country_post <- copyVariable(ds$country, deep = TRUE, name = "Country post")
+ds$country_post <- copyVariable(ds$country, deep = TRUE, name = "Country post")``
 
 questions = c("q1", "country")
 suffixes = c("_pre", "_post")


### PR DESCRIPTION
Allows for grids to be flipped on a case by case basis. Will be useful for: 

- Pre/Post questions where there is more than one recontact and you'd prefer it to be long rather than wider
- Tracking reports where there are too many waves for to continue expanding horizontally. 

Closes #212