### PR TITLE
Issue 212a

### DIFF
--- a/R/reformatResults.R
+++ b/R/reformatResults.R
@@ -308,6 +308,7 @@ reformatVar <- function(var, banner_name, theme, proportions, banner_info, latex
 #' @param var The crunch variable
 #' @param theme The theme object from \link{themeNew}
 getVarInfo <- function(var, theme) {
+
   if_there <- function(str) {
     if (!is.null(str) && !is.na(str) && str != "") {
       return(str)
@@ -322,8 +323,13 @@ getVarInfo <- function(var, theme) {
     format_var_filtertext = if_there(var[["notes"]]),
     format_var_subname = if_there(var[["subname"]])
   )
+
+  if (is.null(var_info$format_var_description))
+    var_info$format_var_description <- var_info$format_var_name
+
   number <- if_there(var[["number"]])
   var_info2 <- list()
+
   for (info_name in intersect(names(theme), names(var_info))) {
     if (!is.null(theme[[info_name]]) && (var$type != "categorical_array" ||
                                          (is.null(theme[[info_name]]$repeat_for_subs) ||

--- a/R/tex-table.R
+++ b/R/tex-table.R
@@ -505,7 +505,12 @@ toplineTableDef <- function(var, tab_definition, header_row, theme) {
 #' @param theme An object created by \link{themeNew}
 latexTableName <- function(var, theme) {
   var_info <- getVarInfo(var, theme)
-  bg_color <- theme[[names(var_info)[1]]]$background_color
+  if (length(var_info) > 0) {
+    bg_color <- theme[[names(var_info)[1]]]$background_color
+  } else {
+    bg_color <- NULL
+  }
+
   if (inherits(var, "ToplineVar")) {
     page_width <- 6.5
   } else {
@@ -519,11 +524,13 @@ latexTableName <- function(var, theme) {
     var_info[[1]] <- paste0(var_info[[1]], " \u2014 ", var_info$formatvarsubname)
     var_info$formatvarsubname <- NULL
   }
-  if (length(var_info) == 0) {
-    # TODO: This shouldn't ever happen. User should be warned
-    warning("Missing variable: ", alias(var))
-    var_info <- list(formatvarname = paste0("\\color{", bg_color, "}{404}"))
-  }
+  # if (length(var_info) == 0) {
+  #   # TODO: This shouldn't ever happen. User should be warned
+  #   warning("Missing variable: ", var$alias)
+  #   if(!is.null(bg_color)) {
+  #     var_info <- list(formatvarname = paste0("\\color{", bg_color, "}{404}"))
+  #   }
+  # }
   out <- paste0(
     "\\addcontentsline{lot}{table}{ ", texEscape(var_info[[1]]), "}\n",
     "\\hangindent=0em \\parbox{", page_width, "in}{\n",

--- a/tests/testthat/ref/tabbook1.tex
+++ b/tests/testthat/ref/tabbook1.tex
@@ -62,7 +62,7 @@
 \midrule
 \endhead
 \midrule
-& \multicolumn{5}{c}{} \\ 
+& \multicolumn{5}{c}{} \\
 \bottomrule
 \endfoot
 \bottomrule
@@ -82,7 +82,7 @@
 \midrule
 \endhead
 \midrule
-& \multicolumn{4}{c}{} \\ 
+& \multicolumn{4}{c}{} \\
 \bottomrule
 \endfoot
 \bottomrule
@@ -109,7 +109,7 @@
 \tbltopa[1.5in]
 \addcontentsline{lot}{table}{ 1. Do you have any of these animals as pets? Please select all that apply.}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{1. Do you have any of these animals as pets? Please select all that apply.}\\ 
+\formatvardescription{1. Do you have any of these animals as pets? Please select all that apply.}\\
 \formatvarfiltertext{Uniform base is True.}} \\
 \addlinespace
 \bannera{}
@@ -272,9 +272,9 @@ Unweighted N & \multicolumn{1}{c}{16} & \multicolumn{1}{c}{4} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 4. }
+\addcontentsline{lot}{table}{ 4. Number of dogs}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{4. }} \\
+\formatvardescription{4. Number of dogs}} \\
 \addlinespace
 \bannera{}
 
@@ -405,9 +405,9 @@ Unweighted N & \multicolumn{1}{c}{12} & \multicolumn{1}{c}{4} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 7. }
+\addcontentsline{lot}{table}{ 7. Country}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{7. }} \\
+\formatvardescription{7. Country}} \\
 \addlinespace
 \bannera{}
 
@@ -448,9 +448,9 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 8. }
+\addcontentsline{lot}{table}{ 8. Age}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{8. }} \\
+\formatvardescription{8. Age}} \\
 \addlinespace
 \bannera{}
 
@@ -495,9 +495,9 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 9. }
+\addcontentsline{lot}{table}{ 9. Age 2}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{9. }} \\
+\formatvardescription{9. Age 2}} \\
 \addlinespace
 \bannera{}
 
@@ -532,9 +532,9 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 10. }
+\addcontentsline{lot}{table}{ 10. Age 3}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{10. }} \\
+\formatvardescription{10. Age 3}} \\
 \addlinespace
 \bannera{}
 
@@ -571,9 +571,9 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 11. }
+\addcontentsline{lot}{table}{ 11. Age 5}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{11. }} \\
+\formatvardescription{11. Age 5}} \\
 \addlinespace
 \bannera{}
 
@@ -614,9 +614,9 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \begin{center}
 
 \tbltopa[1.5in]
-\addcontentsline{lot}{table}{ 12. }
+\addcontentsline{lot}{table}{ 12. Gender}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{12. }} \\
+\formatvardescription{12. Gender}} \\
 \addlinespace
 \bannera{}
 
@@ -706,7 +706,7 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \tbltopa[1.5in]
 \addcontentsline{lot}{table}{ 14. Numeric data with values less then 0.}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{14. Numeric data with values less then 0.}\\ 
+\formatvardescription{14. Numeric data with values less then 0.}\\
 \formatvarfiltertext{Not useful.}} \\
 \addlinespace
 \bannera{}
@@ -752,7 +752,7 @@ Unweighted N & \multicolumn{1}{c}{20} & \multicolumn{1}{c}{6} & \multicolumn{1}{
 \tbltopa[1.5in]
 \addcontentsline{lot}{table}{ 15. Do you have any of these animals as pets? Please select all that apply.}
 \hangindent=0em \parbox{9in}{
-\formatvardescription{15. Do you have any of these animals as pets? Please select all that apply.}\\ 
+\formatvardescription{15. Do you have any of these animals as pets? Please select all that apply.}\\
 \formatvarfiltertext{Uniform base is False.}} \\
 \addlinespace
 \bannera{}

--- a/tests/testthat/ref/topline1.tex
+++ b/tests/testthat/ref/topline1.tex
@@ -68,7 +68,7 @@
 \begin{longtable}{p{0.3in}p{5.5in}}
 \addcontentsline{lot}{table}{ 1. Do you have any of these animals as pets? Please select all that apply.}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{1. Do you have any of these animals as pets? Please select all that apply.}\\ 
+\formatvardescription{1. Do you have any of these animals as pets? Please select all that apply.}\\
 \formatvarfiltertext{Uniform base is True.}} \\
 \longtablesep
 
@@ -109,7 +109,7 @@
 \hangindent=0em \parbox{6.5in}{
 \formatvardescription{3. Name the kinds of pets you have at these locations.}} \\
 \\
- &  & Cat & Dog & Bird & Net: Cat/Dog & 
+ &  & Cat & Dog & Bird & Net: Cat/Dog &
 \endfirsthead
 \multicolumn{6}{c}{\textit{}} \\
 \\
@@ -128,9 +128,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 4. }
+\addcontentsline{lot}{table}{ 4. Number of dogs}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{4. }} \\
+\formatvardescription{4. Number of dogs}} \\
 \longtablesep
 
 & 0-1 \hspace*{0.15em} \dotfill 6\% \\
@@ -190,9 +190,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 7. }
+\addcontentsline{lot}{table}{ 7. Country}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{7. }} \\
+\formatvardescription{7. Country}} \\
 \longtablesep
 
 & Argentina \hspace*{0.15em} \dotfill 0\% \\
@@ -210,9 +210,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 8. }
+\addcontentsline{lot}{table}{ 8. Age}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{8. }} \\
+\formatvardescription{8. Age}} \\
 \longtablesep
 
 & 20-30 \hspace*{0.15em} \dotfill 27\% \\
@@ -232,9 +232,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 9. }
+\addcontentsline{lot}{table}{ 9. Age 2}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{9. }} \\
+\formatvardescription{9. Age 2}} \\
 \longtablesep
 
 & 16 to 34 \hspace*{0.15em} \dotfill 40\% \\
@@ -249,9 +249,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 10. }
+\addcontentsline{lot}{table}{ 10. Age 3}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{10. }} \\
+\formatvardescription{10. Age 3}} \\
 \longtablesep
 
 & 16 to 34 \hspace*{0.15em} \dotfill 40\% \\
@@ -267,9 +267,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 11. }
+\addcontentsline{lot}{table}{ 11. Age 5}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{11. }} \\
+\formatvardescription{11. Age 5}} \\
 \longtablesep
 
 & 16 to 24 \hspace*{0.15em} \dotfill 17\% \\
@@ -287,9 +287,9 @@
 
 \begin{center}
 \begin{longtable}{p{0.3in}p{5.5in}}
-\addcontentsline{lot}{table}{ 12. }
+\addcontentsline{lot}{table}{ 12. Gender}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{12. }} \\
+\formatvardescription{12. Gender}} \\
 \longtablesep
 
 & Male \hspace*{0.15em} \dotfill 54\% \\
@@ -331,7 +331,7 @@
 \begin{longtable}{p{0.3in}p{5.5in}}
 \addcontentsline{lot}{table}{ 14. Numeric data with values less then 0.}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{14. Numeric data with values less then 0.}\\ 
+\formatvardescription{14. Numeric data with values less then 0.}\\
 \formatvarfiltertext{Not useful.}} \\
 \longtablesep
 
@@ -353,7 +353,7 @@
 \begin{longtable}{p{0.3in}p{5.5in}}
 \addcontentsline{lot}{table}{ 15. Do you have any of these animals as pets? Please select all that apply.}
 \hangindent=0em \parbox{6.5in}{
-\formatvardescription{15. Do you have any of these animals as pets? Please select all that apply.}\\ 
+\formatvardescription{15. Do you have any of these animals as pets? Please select all that apply.}\\
 \formatvarfiltertext{Uniform base is False.}} \\
 \longtablesep
 


### PR DESCRIPTION
For some question types, if the dataset variable had no question text (no crunch "description") include_q_number would create a NULL that was passed through, creating an error. 

Now, if crunchtabs comes across a dataset variable that has no description it defaults to the crunch variable name (that which would show up in the crunch.io navigation pane)