### PR TITLE
Fixes regression with pagebreak_in_banner

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: In order to generate custom survey reports, this package provides
     'banners' (cross-tabulations) and codebooks of datasets in the Crunch
     (<https://crunch.io/>) web service. Reports can be written in 'PDF' format
     using 'LaTeX' or in Microsoft Excel '.xlsx' files.
-Version: 1.4.3
+Version: 1.4.4
 Authors@R: c(
     person("Persephone", "Tsebelis", role="aut"),
     person("Kamil", "Sedrowicz", role="aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## crunchtabs 1.4.4
 
-- Fixes a regression where absolutelynopagebreak was duplicated in some situations. (pagebreak_in_banner=TRUE and one_per_page=FALSE)
+- Fixes a regression where absolutelynopagebreak was duplicated or not functional in some situations. (pagebreak_in_banner=TRUE and one_per_page=FALSE)
 
 ## crunchtabs 1.4.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## crunchtabs 1.4.4
+
+- Fixes a regression where absolutelynopagebreak was duplicated in some situations. (pagebreak_in_banner=TRUE and one_per_page=FALSE)
+
 ## crunchtabs 1.4.3
 
 - categorical_arrays were previously spliced into the first position at every question iteration, leading to questions being presented out of vector order in the resulting pdf output. This update patches the results list back together when splicing the array questions in-place. Now, the order of variables is the same as the order presented in the output pdf. (INNOV-498)

--- a/R/tex-table.R
+++ b/R/tex-table.R
@@ -195,7 +195,11 @@ latexTableBody <- function(df, theme, question_alias = NULL) {
       rows <- apply(cbind(rownames(dt), dt), 1, paste, collapse = " & ")
     }
     # Add a newline to each row, then join in a single string
-    return(paste(rows, newline, collapse = "\n"))
+    if(!theme$pagebreak_in_banner) {
+      return(paste(rows, "\\\\*", collapse = "\n"))
+    } else {
+      return(paste(rows, newline, collapse = "\n"))
+    }
   })
 
   # Assemble the components of the table, based on "data_order"
@@ -275,9 +279,9 @@ tableHeader.CrossTabVar <- function(var, theme) {
   }
 
   nopagebreak <- NULL
-  if (!theme$pagebreak_in_banner) {
-    nopagebreak <- "\\begin{absolutelynopagebreak}"
-  }
+  # if (!theme$pagebreak_in_banner) {
+  #   nopagebreak <- "\\begin{absolutelynopagebreak}"
+  # }
 
   header <- paste(
     nopagebreak,

--- a/R/writeLatex.R
+++ b/R/writeLatex.R
@@ -222,12 +222,12 @@ latexReportTables <- function(results, banner, theme) {
     # bottomrule gets wiped out by nopagebreak environment
     # adding one manually
     if (!theme$pagebreak_in_banner) {
-      table = gsub(
+      table <- gsub(
         "\\end{longtable}",
-        "\\bottomrule\\end{longtable}\n\\end{absolutelynopagebreak}",
+        "\\bottomrule\\end{longtable}\n", # \\end{absolutelynopagebreak}",
         table, fixed = TRUE)
-      # table <- noBreaks(table)
     }
+
 
     table_bodies[[i]] <- table
   }

--- a/R/writeLatex.R
+++ b/R/writeLatex.R
@@ -222,14 +222,11 @@ latexReportTables <- function(results, banner, theme) {
     # bottomrule gets wiped out by nopagebreak environment
     # adding one manually
     if (!theme$pagebreak_in_banner) {
-      # table <- gsub(
-      #   "\\end{longtable}",
-      #   "\\bottomrule\\end{longtable}\n",
-      #   table,
-      #   fixed = TRUE
-      # )
-
-      table <- noBreaks(table)
+      table = gsub(
+        "\\end{longtable}",
+        "\\bottomrule\\end{longtable}\n\\end{absolutelynopagebreak}",
+        table, fixed = TRUE)
+      # table <- noBreaks(table)
     }
 
     table_bodies[[i]] <- table

--- a/tests/testthat/test-catArrayToCategoricals.R
+++ b/tests/testthat/test-catArrayToCategoricals.R
@@ -2,7 +2,10 @@ context("catArrayToCategoricals")
 
 test_that("Binds categorical arrays appropriately", {
   questions <- readRDS(test_path("fixtures/catArrayToCategorical_questions.rds"))
-  res <- catArrayToCategoricals(questions, "petloc", labels = NULL)
+  res <- expect_warning(
+    catArrayToCategoricals(questions, "petloc", labels = NULL),
+    "New variables derived from a"
+  )
 
   expect_equal(
     res$petloc_1$crosstabs$Results$`___total___`$proportions,

--- a/tests/testthat/test-write-latex.R
+++ b/tests/testthat/test-write-latex.R
@@ -201,9 +201,9 @@ test_that("Adds nonTabBookSummary as expected", {
 
   res <- latexReportTables(results, NULL, tema)
 
-  # Expect absolutelynopagebreak wraps on all
+  # Expect absolutelynopagebreak wraps on none!
   expect_true(
-    all(grepl("absolutelynopagebreak", res))
+    all(!grepl("absolutelynopagebreak", res))
   )
 
   # Clear page not appended to results


### PR DESCRIPTION
Problem: When a crosstab's banner is exceptionally long, the crosstab table is displayed twice. If the crosstab is presenting a categorical array, the array statements can be so long that the second crosstab is forced to continue on the next page. This PR enforces a pagebreak in these situations when the theme option: `pagebreak_in_banner=FALSE`. 

Ref: https://tex.stackexchange.com/questions/634754/enforcing-next-page-in-longtables